### PR TITLE
doc(README): add example config to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@
 
 	A: Make sure you included the file in the right place and you are using `${colors.COLOR}`
 
+-	Q: **_"How do I use the colour file"_**
+
+	A: The exact theme is up to you, but something like [this](https://github.com/catppuccin/polybar/issues/1#issuecomment-1561818935) can help you get started.
+
+
 ## 💝 Thanks to
 
 - [justTOBBI](https://github.com/justTOBBI)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 -	Q: **_"How do I use the color file"_**
 
-	A: The exact theme is up to you, but something like [this](https://github.com/catppuccin/polybar/issues/1#issuecomment-1561818935) can help you get started.
+	A: The exact theme is up to you, but a basic config can be found in [catppuccin/polybar#1 (comment)](https://github.com/catppuccin/polybar/issues/1#issuecomment-1561818935) to help you get started.
 
 
 ## 💝 Thanks to

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 	A: Make sure you included the file in the right place and you are using `${colors.COLOR}`
 
--	Q: **_"How do I use the colour file"_**
+-	Q: **_"How do I use the color file"_**
 
 	A: The exact theme is up to you, but something like [this](https://github.com/catppuccin/polybar/issues/1#issuecomment-1561818935) can help you get started.
 


### PR DESCRIPTION
This improves the FAQ to include a basic example. Helps close #1.